### PR TITLE
Add solidproject.org development and maintenance task force

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Team members may be added or removed from this task force by a majority vote at 
 * [Diversity Outreach](/tasks/diversity-outreach.md)
 * [Manage Social Media](/tasks/manage-social-media.md)
 * [Practitioners Engagement](/tasks/practitioners-engagement.md)
+* [solidproject.org development and maintenance](/tasks/solidproject.org-development-maintenance)
 
 ### One-off Task Forces
 

--- a/tasks/solidproject.org-development-maintenance.md
+++ b/tasks/solidproject.org-development-maintenance.md
@@ -1,0 +1,10 @@
+# solidproject.org website development and maintenance
+
+## Responsibilities
+
+Members of the solidproject.org website development and maintenance are responsible for developing the website and keeping it up to date, ensuring that the architecture and the information are useful to users which accurately reflects the project's goals and values. This task force will seek feedback and report to the wider Solid Team on developments and updates via pull requests and in meetings when needed.
+
+## Task force members
+
+* Virginia Balseiro (co-lead)
+* Sarven Capadisli (co-lead)


### PR DESCRIPTION
Adding the development and maintenance of the solidproject.org website as a ongoing task force of the Team.

I am proposing @csarven  and myself as co-leads of this task force, but I also want to invite other team members who might be interested to add their name as a commit suggestion.

That aside, anyone can contribute to the website at any time without being formally a task force member.