### PR TITLE
Adding a list of explicit collaborations to Website Task Force

### DIFF
--- a/tasks/solidproject.org-development-maintenance.md
+++ b/tasks/solidproject.org-development-maintenance.md
@@ -4,6 +4,13 @@
 
 Members of the solidproject.org website development and maintenance task force are responsible for developing the website and keeping it up to date, ensuring that the architecture and information are useful to users and accurately reflect the project's goals and values. This task force will seek feedback from and report to the Solid Team on developments and updates via pull requests and in meetings when needed.
 
+### Collaborations
+
+The team will collaborate with:
+
+- [Solid Creators](https://github.com/solid/process/blob/main/creators.md): Create content for the website
+- [Solid Admins](https://github.com/solid/process/blob/main/administrators.md): Coordinate updates to the website
+
 ## Task force members
 
 * Virginia Balseiro (co-lead)


### PR DESCRIPTION
I suggest adding a list of collaborating teams explicitly, so that any confusion about the work between these teams can be sorted out.