### PR TITLE
Removing myself as member of Solid Team

### DIFF
--- a/tasks/solidproject.org-development-maintenance.md
+++ b/tasks/solidproject.org-development-maintenance.md
@@ -8,4 +8,3 @@ Members of the solidproject.org website development and maintenance task force a
 
 * Virginia Balseiro (co-lead)
 * Sarven Capadisli (co-lead)
-* Arne Hassel

--- a/team.md
+++ b/team.md
@@ -28,4 +28,3 @@ Solid Team members must attend Solid Team meetings on a semi-regular basis. They
 | Hadrian Zbarcea   | [Inrupt](https://www.inrupt.com/) | |
 | Giselle Wenban | [Inrupt](https://www.inrupt.com/) | https://id.inrupt.com/gisellewenban |
 | Ted Thibodeau     | [OpenLink Software](https://www.openlinksw.com/) | http://id.myopenlink.net/dataspace/person/tthibodeau#this |
-| Arne Hassel       | N/A | https://arnehassel.solidcommunity.net/profile/card#me |


### PR DESCRIPTION
I've decided to remove myself from the Solid Team. My primary reason is that I don't have the excess of time and energy needed for the team, but also because I'm disappointed with the overall experience I'm having as a member. The following is an attempt at constructive criticism of the team based on my experience with it.

The team has a big problem with focus and resources. It simply doesn't seem like most members have time and motivation for the team. Granted, it's a team of volunteers, so the amount of work will naturally fluctuate because of that, but given the ambitions of the team (and the need of the Solid project in general), I would've wished for more structure, transparency, and resources.

I've come to the belief that the group needs funding. I imagine it could be as simple as companies paying their employees for work that they’re doing for the group. These contributions should have be open and offer transparency (e.g. in the form of budgets and/or public plans).

Honestly, I would be ok with companies running the team, as long as there are transparency in the work being done, and good processes for how to involve stakeholders from the community. An example of this would be to involve Noel de Martin in the work on the apps-page, as he has invested a lot of time into his apps and app development in general, and just removing it without consulting people like him feels like an insult. Although Noel is an extreme example, there are many people like him in the community, and I think we can become a lot better in communicating the team’s work with them, and involve them (if they want) where appropriate. Given the amount of value these people have contributed to Solid, I feel that this is the least we could do to thank them.

Involvement like this isn’t being done very well right now. As an example of this, although I’m ok with the upcoming new website (tbh I’m not blown away by it, but it’s a change, and it’s a good starting point for later development), I don’t think the process to get there has been open and transparent at all. Some of this has been pointed out already, e.g. Sarven’s points in https://github.com/solid/solidproject.org/issues/816, and I hope it’s something we can learn from in the team’s future endeavours.

I think a team like this, where you have Tim and a bunch of people working on efforts that are valuable to the overall Solid project, coordinating and communicating their work with the wider community, can be very good for the Solid project. I even think it might be vital for the project’s survival in the long run. But again, I think a vital part of the team becoming successful is getting funding.