### PR TITLE
Remove Sarven and Virginia from Website Task

### DIFF
--- a/tasks/solidproject.org-development-maintenance.md
+++ b/tasks/solidproject.org-development-maintenance.md
@@ -6,6 +6,4 @@ Members of the solidproject.org website development and maintenance task force a
 
 ## Task force members
 
-* Virginia Balseiro (co-lead)
-* Sarven Capadisli (co-lead)
 * Arne Hassel


### PR DESCRIPTION
After some consideration, we (Sarven and I) have decided to remove ourselves from the Website maintainance task. See also Arne stepping down from this task: https://github.com/solid/team/pull/75/files#diff-4ccdd6503d67a6be1c52038d2593c54cdfb6787ed46c0a8c3d074a48037f0225

Importance of proper IA/UX towards a successful re-launch of the website was raised to the Solid Team in:

* https://github.com/solid/team/blob/main/meetings/2023-12-13.md
* https://github.com/solid/team/blob/main/meetings/2024-01-10.md

and in issues and PRs:

* https://github.com/solid/solidproject.org/issues/816
* https://github.com/solid/solidproject.org/pull/836 contains a (non-exhaustive) list of outstanding issues which have not to date been fully addressed.
* https://github.com/solid/solidproject.org/issues/842
* https://github.com/solid/solidproject.org/pull/852
* https://github.com/solid/solidproject.org/pull/854
* https://github.com/solid/solidproject.org/pull/856
* https://github.com/solid/solidproject.org/issues/866
* https://github.com/solid/solidproject.org/pull/869
* https://github.com/solid/solidproject.org/pull/876
* ...

and in addition to numerous conversations in the Solid Team (private) chat.

With regards to the remaining work to be done for the launch of the new website:

We've done the bulk of the implementation work as well as documenting outstanding issues. If anyone wants to carry on from here, they can use our suggestions if they'd like to. We would also like to remind the Team of the importance of community contributions in the form of PRs and issues that should make their way into the new website as well, which will take triaging and updating.

We don't wish anyone to perceive our work as "preventing" or "blocking" anyone or the Solid Team, so, if the consensus is to merge https://github.com/solid/solidproject.org/pull/876 for any reason, it is still possible by 1) clicking on re-open PR 2) clicking merge.

PR 876 (along with other mentions as linked in the list above) ignored significant issues with the work in the redesign branch, stemming from a lack of clarity and strategy around things like missing designs, resources, redirects, and so on. Our intention with https://github.com/solid/solidproject.org/pull/836 was to get the work to a good stage and document the remaining work, so that others could contribute in addressing the outstanding issues as a team effort. That has not happened, which is why this Task force deems the work still incomplete and not ready to merge.

As mentioned in the PR, we'd recommend against re-launching the website with the new "design" in that proposed state because it breaks a number of things on the website and raises significant regression issues. But again, at this juncture, it is on anyone that wishes to take these considerations and work out a path that's best for the project.

That said, we remain available to anyone that wishes to take on the ownership or lead on this task. We will find ways to contribute to other Team tasks.
